### PR TITLE
Add high-level handling of DtmfReceived event

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@
 
 - Optional asterisk reconnection. Fixes [#32](https://github.com/daniele77/aricpp/issues/32) 
 - Fix ToString(JsonTree). Fixes #30
+- Add high-level handler for DTMF received event
 
 ## Version 0.9.1 - 2020-10-29
 

--- a/samples/play_and_record.cpp
+++ b/samples/play_and_record.cpp
@@ -145,8 +145,7 @@ int main( int argc, char* argv[] )
             }
         );
 
-        client.OnEvent("ChannelDtmfReceived", [&](const aricpp::JsonTree& event) {
-            auto digit = aricpp::Get<std::string>(event, { "digit" });
+        model.OnChannelDtmfReceived([&](std::shared_ptr<aricpp::Channel> /*channel*/, const std::string &digit) {
             std::cout << "Received digit " << digit << std::endl;
             if (digit == "1")
             {


### PR DESCRIPTION
As there is a high-level way to send DTMF, here is an extension to also have a high-level version of the DtmfReceived event. It's based on the clang-format branch.

@daniele77 Let me know when I should provide a version of this PR that's based on current master instead of the reformatted clang-format PR.